### PR TITLE
[Add] agregar test para la idempotencia

### DIFF
--- a/tests/test_idempotency.bats
+++ b/tests/test_idempotency.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+
+setup() {
+  mkdir -p out dist
+  rm -f out/.res_checksum out/resoluciones.csv dist/*.tar.gz
+  # preparar domains base
+  printf "example.com\n" > /tmp/dom_base.txt
+  cp /tmp/dom_base.txt docs/domains.txt
+}
+
+teardown() {
+  rm -f /tmp/dom_base.txt
+  rm -f docs/domains.txt
+  rm -f out/.res_checksum out/resoluciones.csv dist/*.tar.gz
+}
+
+@test "build-cache es idempotente cuando no hay cambios" {
+  # primer build -> debe crear out/resoluciones.csv y cache
+  run make build-cache
+  [ "$status" -eq 0 ]
+  [ -f out/resoluciones.csv ]
+  [ -f out/.res_checksum ]
+  checksum1="$(cat out/.res_checksum)"
+
+  # segundo build sin cambios -> debe saltar (exit 0) y no modificar checksum
+  sleep 1
+  run make build-cache
+  [ "$status" -eq 0 ]
+  checksum2="$(cat out/.res_checksum)"
+  [ "$checksum1" = "$checksum2" ]
+}
+
+@test "build-cache detecta cambios en docs/domains.txt" {
+  # primer build
+  run make build-cache
+  [ "$status" -eq 0 ]
+  checksum1="$(cat out/.res_checksum)"
+
+  # modificar lista de dominios -> agregar otro dominio
+  printf "example.org\n" >> docs/domains.txt
+
+  # segundo build -> debe actualizar cache y generar nuevo checksum
+  run make build-cache
+  [ "$status" -eq 0 ]
+  checksum2="$(cat out/.res_checksum)"
+  [ "$checksum1" != "$checksum2" ]
+}
+
+@test "pack genera tar.gz con RELEASE" {
+  run make pack RELEASE=v9.9.9
+  [ "$status" -eq 0 ]
+  ls dist/proyecto2-v9.9.9.tar.gz >/dev/null
+}


### PR DESCRIPTION
## Pull Request: Añadir pruebas de idempotencia

### Descripción
Este PR agrega el archivo `tests/test_idempotency.bats`, que contiene pruebas automatizadas para verificar la **idempotencia** del proceso de construcción (`make build-cache`) y la correcta generación del paquete (`make pack`).

### Cambios realizados
- Se crea el archivo `tests/test_idempotency.bats` con las siguientes pruebas:
  1. **`build-cache es idempotente cuando no hay cambios`**  
     - Verifica que ejecutar `make build-cache` dos veces sin modificar los archivos no cambia el checksum.
  2. **`build-cache detecta cambios en docs/domains.txt`**  
     - Comprueba que al modificar `docs/domains.txt`, el checksum cambia y se actualiza la caché.
  3. **`pack genera tar.gz con RELEASE`**  
     - Asegura que el comando `make pack RELEASE=vX.Y.Z` genera correctamente el archivo comprimido en `dist/`.

### Detalles técnicos
- Se utiliza **Bats (Bash Automated Testing System)** para las pruebas.
- Se crean y limpian directorios temporales (`out`, `dist`) en las funciones `setup()` y `teardown()`.
- Se valida la existencia de archivos generados (`out/resoluciones.csv`, `out/.res_checksum`, `dist/*.tar.gz`).
- Se comprueba la integridad mediante comparación de checksums.

### Cómo ejecutar las pruebas
```bash
bats tests/test_idempotency.bats
```

### Resultados esperados
- Todas las pruebas deben pasar con estado `0`.
- El checksum solo cambia cuando se modifica `docs/domains.txt`.
- El archivo `dist/proyecto2-v9.9.9.tar.gz` se genera correctamente.

### Notas adicionales
- Este test garantiza que el proceso de build es **reproducible e idempotente**.