### PR TITLE
[Add] Culminar Makefile y documentacion del sprint 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,45 @@
-# Variables
+# Makefile completo Sprint1+Sprint2+Sprint3
 SHELL := /bin/bash
 
-.PHONY: tools build run test clean history diff report
+.PHONY: help tools build build-cache run test clean history diff report pack
 
+# Default release (puedes sobreescribir con RELEASE=v1.2.3 make pack)
+RELEASE ?= v1.0.0
+
+help:
+	@echo "Targets disponibles:"
+	@echo "  make tools        -> verifica herramientas (dig, bats)"
+	@echo "  make build        -> genera resoluciones (sin cache)"
+	@echo "  make build-cache  -> genera resoluciones si inputs cambiaron (caché incremental)"
+	@echo "  make run          -> alias de build-cache"
+	@echo "  make history      -> guarda histórico out/history-<ts>.csv"
+	@echo "  make diff         -> compara los 2 últimos históricos y genera reporte"
+	@echo "  make report       -> alias de diff"
+	@echo "  make pack         -> empaqueta proyecto en dist/proyecto2-$(RELEASE).tar.gz"
+	@echo "  make test         -> ejecuta bats tests/"
+	@echo "  make clean        -> limpia out/ y dist/"
+
+# herramientas
 tools:
 	@command -v dig >/dev/null 2>&1 || { echo "dig no está instalado"; exit 1; }
 	@command -v bats >/dev/null 2>&1 || { echo "bats no está instalado"; exit 1; }
 	@echo "Herramientas verificadas."
 
+# Sprint 1 basic build (sin cache)
 build:
-	@echo "Generando resoluciones..."
+	@echo "Generando resoluciones (no cache)..."
 	@./src/resolve.sh
 
-run: build
-	@echo "Ejecución completa de auditor DNS finalizada."
+# Sprint 3: build con caché incremental
+build-cache:
+	@echo "Generando resoluciones con verificación de caché..."
+	@./src/build_with_cache.sh
 
-test:
-	@echo "Ejecutando pruebas con Bats..."
-	@bats tests/
+# run es alias de build-cache
+run: build-cache
+	@echo "Ejecución completa de auditor DNS (run)."
 
-clean:
-	@rm -rf out/*.csv out/diff-*.txt out/diff-*.csv out/history-*.csv
-	@echo "Archivos temporales eliminados."
-
+# Sprint 2: history/diff/report (ya incluídos)
 history:
 	@echo "Guardando histórico actual..."
 	@./src/save_history.sh out/resoluciones.csv
@@ -33,3 +50,16 @@ diff:
 
 report: diff
 	@echo "Reporte generado en carpeta out/"
+
+# empaquetado reproducible
+pack:
+	@echo "Generando paquete dist/proyecto2-$(RELEASE).tar.gz ..."
+	@RELEASE=$(RELEASE) ./src/pack.sh
+
+test:
+	@echo "Ejecutando pruebas con Bats..."
+	@bats tests/
+
+clean:
+	@rm -rf out/*.csv out/diff-*.txt out/diff-*.csv out/history-*.csv out/.res_checksum dist/*
+	@echo "Archivos temporales eliminados."

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,17 @@ make diff
 # revisar resultados en out
 ```
 
+## Ejecutar pipeline de pack
+```bash
+make pack
+# revisar resultados en dist/
+```
+
+## Ejecutar pipeline de clean
+```bash
+make clean
+```
+
 **Videos:**
 
 **Video-Sprint-1**:

--- a/docs/bitacora-sprint-3.md
+++ b/docs/bitacora-sprint-3.md
@@ -1,0 +1,8 @@
+
+## Sprint 3: Parametrización, Caché e Integración Final
+- Fecha: 04/10/2025
+- Grupo: 13
+- Actividades realizadas:
+  - Caché incremental en el Makefile
+  - Empaquetado reproducible en dist/
+  - Pruebas automatizada Bats de idempotencia.


### PR DESCRIPTION
# Pull Request — Sprint 3: Documentacion y Makefile

## Archivos modificados
- `docs/bitacora-sprint-3.md`
- `docs/README.md`
- `Makefile`

---

## Descripción general

Este PR incorpora las actualizaciones correspondientes al **Sprint 3**, centradas en la **parametrización del pipeline**, la **implementación de caché incremental** y la **documentacion final del proyecto**.

---

## Cambios por archivo

### `docs/bitacora-sprint-3.md`
Se documentan las actividades del Sprint 3:
- Caché incremental en el Makefile  
- Empaquetado reproducible en `dist/`  
- Pruebas automatizadas Bats de idempotencia  

---

### `docs/README.md`
Se amplía la documentación con:
- Ejemplos de ejecución de los nuevos target del Makefile  

---

### `Makefile`
Se actualiza con:
- **Caché incremental** (`build-cache`)  
- **Alias `run`** para `build-cache`  
- **Empaquetado reproducible** (`pack`) con variable `RELEASE`  

---
